### PR TITLE
Euclidean space without Lebesgue measure on it

### DIFF
--- a/src/domains.jl
+++ b/src/domains.jl
@@ -20,7 +20,7 @@ For example, `@domain ℝ RealNumbers` is equivalent to
 """
 macro domain(name, T)
     sname = String(name)
-    
+
     name = esc(name)
     quote
         struct $T <: AbstractDomain end
@@ -65,3 +65,21 @@ testvalue(::IntegerRange{lo, hi}) where {lo, hi} = lo
 
 
 struct RealInterval{lo, hi} <: AbstractDomain end
+
+
+###########################################################
+# Euclidean space
+
+struct EuclideanSpace{T} <: AbstractDomain
+    dimension::T
+end
+
+function Base.show(io::IO, es::EuclideanSpace)
+    print(io, "ℝ ^ ", dimension(es))
+end
+
+Base.:^(::RealNumbers, n::Integer) = EuclideanSpace(n)
+
+dimension(es::EuclideanSpace) = es.dimension
+
+export EuclideanSpace, dimension


### PR DESCRIPTION
Hey @cscherrer
Here is the implementation of the Euclidean space domain. Since you told me to leave out the part involving static integers, I'm not sure how to add the Lebesgue measure on R^n since we have no way of specifying the dimension in the type (and hence no grasp on the `testvalue` or `sampletype`).
Also, don't forget to replace `dimension` with `TV.dimension` in MeasureTheory.jl.