### PR TITLE
logjac for non-square matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeasureBase"
 uuid = "fa1605e6-acd5-459c-a1e6-7e635759db14"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"

--- a/src/MeasureBase.jl
+++ b/src/MeasureBase.jl
@@ -3,6 +3,7 @@ module MeasureBase
 const logtwo = log(2.0)
 
 using Random
+import Random: rand!
 
 using ConcreteStructs
 using MLStyle

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -45,6 +45,11 @@ end
     return x
 end
 
+@inline function apply!(x, f::AffineTransform{(:ω,),::Factorization}, z)
+    ldiv!(x, f.ω, z)
+    return x
+end
+
 @inline function apply!(x, f::AffineTransform{(:ω,)}, z)
     ldiv!(x, factorize(f.ω), z)
     return x

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -114,11 +114,13 @@ function paramnames(::Type{A}) where {N,M, A<:Affine{N,M}}
     tuple(union(N, paramnames(M))...)
 end
 
-Base.propertynames(d::Affine{N}) where {N} = N ∪ (:parent,)
+Base.propertynames(d::Affine{N}) where {N} = N ∪ (:parent,:f)
 
 @inline function Base.getproperty(d::Affine, s::Symbol) 
     if s === :parent
         return getfield(d, :parent)
+    elseif s === :f 
+        return getfield(d, :f)
     else
         return getproperty(getfield(d, :f), s)
     end

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -87,6 +87,12 @@ logjac(f::AffineTransform{(:μ,)}) = 0.0
     parent::M
 end
 
+function testvalue(d::Affine)
+    f = getfield(d, :f)
+    z = testvalue(parent(d))
+    return f(z)
+end
+
 Base.size(d::Affine) = size(getfield(d, :f))
 
 Affine(nt::NamedTuple, μ::AbstractMeasure) = affine(nt, μ)

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -45,7 +45,7 @@ end
     return x
 end
 
-@inline function apply!(x, f::AffineTransform{(:ω,),::Factorization}, z)
+@inline function apply!(x, f::AffineTransform{(:ω,), Tuple{F}}, z) where {F<:Factorization}
     ldiv!(x, f.ω, z)
     return x
 end

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -134,7 +134,12 @@ logdensity(d::Affine{(:μ,:ω)}, x) = logdensity(d.parent, d.ω * (x - d.μ))
 # logdensity(d::Affine{(:μ,:ω)}, x) = logdensity(d.parent, d.σ \ (x - d.μ))
 function logdensity(d::Affine{(:μ,:σ), Tuple{AbstractVector, AbstractMatrix}}, x)
     z = x - d.μ
-    ldiv!(factorize(d.σ), z)
+    σ = d.σ
+    if σ isa Factorization
+        ldiv!(σ, z)
+    else
+        ldiv!(factorize(σ), z)
+    end
     logdensity(d.parent, z)
 end
     

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -23,7 +23,14 @@ Base.propertynames(d::AffineTransform{N}) where {N} = N
 (f::AffineTransform{(:μ,:ω)})(x) = f.ω \ x + f.μ
 
 
-logjac(x::AbstractMatrix) = first(logabsdet(x))
+function logjac(x::AbstractMatrix) 
+    (m,n) = size(x)
+    m == n && return first(logabsdet(x))
+
+    # Equivalent to sum(log, svdvals(x)), but much faster
+    m > n && return first(logabsdet(x' * x)) / 2
+    return first(logabsdet(x * x')) / 2
+end
 
 logjac(x::Number) = log(abs(x))
 

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -93,8 +93,6 @@ function testvalue(d::Affine)
     return f(z)
 end
 
-Base.size(d::Affine) = size(getfield(d, :f))
-
 Affine(nt::NamedTuple, μ::AbstractMeasure) = affine(nt, μ)
 
 Affine(nt::NamedTuple) = affine(nt)

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -135,7 +135,7 @@ logdensity(d::Affine{(:μ,:σ)}, x) = logdensity(d.parent, d.σ \ (x - d.μ))
 logdensity(d::Affine{(:μ,:ω)}, x) = logdensity(d.parent, d.ω * (x - d.μ)) 
 
 # logdensity(d::Affine{(:μ,:ω)}, x) = logdensity(d.parent, d.σ \ (x - d.μ))
-function logdensity(d::Affine{(:μ,:σ), Tuple{AbstractVector, AbstractMatrix}}, x)
+@inline function logdensity(d::Affine{(:μ,:σ), Tuple{AbstractVector, AbstractMatrix}}, x)
     z = x - d.μ
     σ = d.σ
     if σ isa Factorization
@@ -147,7 +147,7 @@ function logdensity(d::Affine{(:μ,:σ), Tuple{AbstractVector, AbstractMatrix}},
 end
     
 # logdensity(d::Affine{(:μ,:ω)}, x) = logdensity(d.parent, d.ω * (x - d.μ))
-function logdensity(d::Affine{(:μ,:ω), Tuple{AbstractVector, AbstractMatrix}}, x)
+@inline function logdensity(d::Affine{(:μ,:ω), Tuple{AbstractVector, AbstractMatrix}}, x)
     z = x - d.μ
     lmul!(d.ω, z)
     logdensity(d.parent, z)

--- a/src/combinators/factoredbase.jl
+++ b/src/combinators/factoredbase.jl
@@ -7,7 +7,7 @@ struct FactoredBase{R,C,V,B} <: AbstractMeasure
     base :: B
 end
 
-function logdensity(d::FactoredBase, x)
+@inline function logdensity(d::FactoredBase, x)
     d.inbounds(x) || return -Inf
     d.constℓ + d.varℓ()
 end

--- a/src/combinators/pointwise.jl
+++ b/src/combinators/pointwise.jl
@@ -27,7 +27,7 @@ Base.length(m::PointwiseProductMeasure{T}) where {T} = length(m.data)
 
 ⊙(args...) = pointwiseproduct(args...)
 
-function logdensity(d::PointwiseProductMeasure, x)
+@inline function logdensity(d::PointwiseProductMeasure, x)
     sum((logdensity(dⱼ, x) for dⱼ in d.data))
 end
 

--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -78,7 +78,7 @@ params(::Type{P}) where {F,P<:ProductMeasure{F,<:Fill}} = params(D)
 end
 
 # Same as PowerMeasure
-function logdensity(d::ProductMeasure{F,<:Fill}, x) where {F}
+@inline function logdensity(d::ProductMeasure{F,<:Fill}, x) where {F}
     d1 = d.f(first(d.pars))
     sum(xj -> logdensity(d1, xj), x)
 end

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -193,8 +193,8 @@ end
 #     set.(marginals(d), params, p)
 # end
 
-function logdensity(μ::ProductMeasure, ν::ProductMeasure, x)
-    sum(zip(marginals(μ), marginals(ν), x)) do μ_ν_x
-        logdensity(μ_ν_x...)
-    end
-end
+# function logdensity(μ::ProductMeasure, ν::ProductMeasure, x)
+#     sum(zip(marginals(μ), marginals(ν), x)) do μ_ν_x
+#         logdensity(μ_ν_x...)
+#     end
+# end

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -62,7 +62,7 @@ function Base.show(io::IO, μ::ProductMeasure{F,T}) where {F,T <: Tuple}
     print(io, join(string.(marginals(μ)), " ⊗ "))
 end
 
-function logdensity(d::ProductMeasure{F,T}, x::Tuple) where {F,T<:Tuple}
+@inline function logdensity(d::ProductMeasure{F,T}, x::Tuple) where {F,T<:Tuple}
     mapreduce(logdensity, +, d.f.(d.pars), x)
 end
 

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -192,3 +192,9 @@ end
 # function Accessors.set(d::ProductMeasure{F,T}, ::typeof(params), p::Tuple) where {F, T<:Tuple}
 #     set.(marginals(d), params, p)
 # end
+
+function logdensity(μ::ProductMeasure, ν::ProductMeasure, x)
+    sum(zip(marginals(μ), marginals(ν), x)) do μ_ν_x
+        logdensity(μ_ν_x...)
+    end
+end

--- a/src/combinators/restricted.jl
+++ b/src/combinators/restricted.jl
@@ -3,12 +3,14 @@ struct RestrictedMeasure{F,M} <: AbstractMeasure
     base::M
 end
 
-function logdensity(d::RestrictedMeasure, x)
+@inline function logdensity(d::RestrictedMeasure, x)
     d.f(x) || return -Inf
+    return 0.0
 end
 
 function density(d::RestrictedMeasure, x)
     d.f(x) || return 0.0
+    return 1.0
 end
 
 basemeasure(μ::RestrictedMeasure) = μ.base

--- a/src/density.jl
+++ b/src/density.jl
@@ -98,12 +98,12 @@ Define a new measure in terms of a density `f` over some measure `base`.
 
 # TODO: `density` and `logdensity` functions for `DensityMeasure`
 
-function logdensity(μ::T, ν::T, x) where {T<:AbstractMeasure}
+@inline function logdensity(μ::T, ν::T, x) where {T<:AbstractMeasure}
     μ==ν && return 0.0
     invoke(logdensity, Tuple{AbstractMeasure, AbstractMeasure, typeof(x)}, μ, ν, x)
 end
 
-function logdensity(μ::AbstractMeasure, ν::AbstractMeasure, x)
+@inline function logdensity(μ::AbstractMeasure, ν::AbstractMeasure, x)
     α = basemeasure(μ)
     β = basemeasure(ν)
 

--- a/src/density.jl
+++ b/src/density.jl
@@ -135,6 +135,17 @@ function logdensity(μ::AbstractMeasure, ν::AbstractMeasure, x)
     return ℓ
 end
 
+function logpdf(d::AbstractMeasure, x)
+    _logpdf(d, basemeasure(d), x, zero(Float64))
+end
+
+@inline function _logpdf(d::AbstractMeasure, β::AbstractMeasure, x, ℓ::Float64)
+    d === β && return ℓ
+    Δℓ = logdensity(d, x)
+    # @show Δℓ, d
+    _logpdf(β, basemeasure(β), x, ℓ + Δℓ)
+end
+
 logdensity(::Lebesgue, ::Lebesgue, x) = 0.0
 
 # logdensity(::Lebesgue{ℝ}, ::Lebesgue{ℝ}, x) = zero(x)

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -6,9 +6,12 @@ Base.rand(T::Type, μ::AbstractMeasure) = rand(Random.GLOBAL_RNG, T, μ)
 
 Base.rand(rng::AbstractRNG, d::AbstractMeasure) = rand(rng, Float64, d)
 
-@inline Random.rand!(d::AbstractMeasure, arr::AbstractArray) = rand!(GLOBAL_RNG, d, arr)
+@inline Random.rand!(d::AbstractMeasure, args...) = rand!(GLOBAL_RNG, d, args...)
 
-
+function Base.rand(rng::AbstractRNG, ::Type{T}, d::AbstractMeasure) where {T}
+    x = testvalue(d)
+    rand!(d, x)
+end
 
 # struct ArraySlot{A,I}
 #     arr::A

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -8,10 +8,11 @@ Base.rand(rng::AbstractRNG, d::AbstractMeasure) = rand(rng, Float64, d)
 
 @inline Random.rand!(d::AbstractMeasure, args...) = rand!(GLOBAL_RNG, d, args...)
 
-function Base.rand(rng::AbstractRNG, ::Type{T}, d::AbstractMeasure) where {T}
-    x = testvalue(d)
-    rand!(d, x)
-end
+# TODO: Make this work
+# function Base.rand(rng::AbstractRNG, ::Type{T}, d::AbstractMeasure) where {T}
+#     x = testvalue(d)
+#     rand!(d, x)
+# end
 
 # struct ArraySlot{A,I}
 #     arr::A

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -8,6 +8,12 @@ Base.rand(rng::AbstractRNG, d::AbstractMeasure) = rand(rng, Float64, d)
 
 @inline Random.rand!(d::AbstractMeasure, args...) = rand!(GLOBAL_RNG, d, args...)
 
+function Base.rand(rng::Random.AbstractRNG, ::Type{T}, d::Affine) where {T}
+    z = rand(rng, T, parent(d))
+    f = getfield(d, :f)
+    return f(z)
+end
+
 # TODO: Make this work
 # function Base.rand(rng::AbstractRNG, ::Type{T}, d::AbstractMeasure) where {T}
 #     x = testvalue(d)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,9 +3,9 @@ const EmptyNamedTuple = NamedTuple{(),Tuple{}}
 showparams(io::IO, ::EmptyNamedTuple) = print(io, "()")
 showparams(io::IO, nt::NamedTuple) = print(io, nt)
 
-function fix(f, x)
+@inline function fix(f, x)
     y = f(x)
-    while x ≠ y
+    while x ≢ y
         (x,y) = (y, f(y))
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,7 +152,15 @@ end
     d = ∫exp(x -> -x^2, Lebesgue(ℝ))
     a = Affine((σ=[1 0]',), d^1)
     x = randn(2)
+    y = randn(1)
     @test logpdf(a, x) ≈ logpdf(d, inv(a.f)(x)[1])
+    @test logpdf(a, a.f(y)) ≈ logpdf(d^1, y)
+
+    b = Affine((ω=[1 0]'',), d^1)
+    @test logpdf(b, x) ≈ logpdf(d, inv(b.f)(x)[1])
+    @test logpdf(b, b.f(y)) ≈ logpdf(d^1, y)
+
+    @test 
 end
 
 @testset "For" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,8 +159,6 @@ end
     b = Affine((ω=[1 0]'',), d^1)
     @test logpdf(b, x) ≈ logpdf(d, inv(b.f)(x)[1])
     @test logpdf(b, b.f(y)) ≈ logpdf(d^1, y)
-
-    @test 
 end
 
 @testset "For" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Random
 using LinearAlgebra
 
 using MeasureBase
+using MeasureBase: logpdf
 
 using Aqua
 Aqua.test_all(MeasureBase; ambiguities=false, unbound_args=false)
@@ -147,6 +148,11 @@ end
     @test logdensity(Affine((σ=σ,), d^3), x) ≈  logdensity(Affine((ω=ω,), d^3), x)
     @test logdensity(Affine((μ=μ,), d^3), x) ≈  logdensity(d^3, x-μ)
 
+
+    d = ∫exp(x -> -x^2, Lebesgue(ℝ))
+    a = Affine((σ=[1 0]',), d^1)
+    x = randn(2)
+    @test logpdf(a, x) ≈ logpdf(d, inv(a.f)(x)[1])
 end
 
 @testset "For" begin


### PR DESCRIPTION
```julia
function logjac(x::AbstractMatrix) 
    (m,n) = size(x)
    m == n && return first(logabsdet(x))

    # Equivalent to sum(log, svdvals(x)), but much faster
    m > n && return first(logabsdet(x' * x)) / 2
    return first(logabsdet(x * x')) / 2
end
```

@sethaxen @mschauer does this look right?

In the SVD `A = U * Diagonal(S) * Vt`, the `U` and `Vt` are orthogonal. If these are isomorphisms or embeddings, they don't affect the geometry, so only the singular values matter. So I think this works as long as `m >= n` for sigma or `m <= n` for omega. But I want to be sure I'm not missing something. 