### PR TITLE
Affine

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeasureBase"
 uuid = "fa1605e6-acd5-459c-a1e6-7e635759db14"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"

--- a/src/MeasureBase.jl
+++ b/src/MeasureBase.jl
@@ -5,6 +5,7 @@ const logtwo = log(2.0)
 using Random
 import Random: rand!
 
+using FillArrays
 using ConcreteStructs
 using MLStyle
 
@@ -46,13 +47,14 @@ if VERSION < v"1.7.0-beta1.0"
     end
 end
 
+include("kernel.jl")
+include("parameterized.jl")
 include("combinators/mapsto.jl")
 include("combinators/half.jl")
 include("exp.jl")
 include("domains.jl")
 include("utils.jl")
 include("absolutecontinuity.jl")
-include("parameterized.jl")
 include("macros.jl")
 include("resettablerng.jl")
 
@@ -70,7 +72,6 @@ include("combinators/for.jl")
 include("combinators/power.jl")
 include("combinators/affine.jl")
 include("combinators/spikemixture.jl")
-include("kernel.jl")
 include("combinators/likelihood.jl")
 include("combinators/pointwise.jl")
 include("combinators/restricted.jl")

--- a/src/MeasureBase.jl
+++ b/src/MeasureBase.jl
@@ -22,6 +22,7 @@ sampletype(μ::AbstractMeasure) = typeof(testvalue(μ))
 
 export logdensity
 export basemeasure
+export basekernel
 
 using LogExpFunctions: logsumexp
 

--- a/src/MeasureBase.jl
+++ b/src/MeasureBase.jl
@@ -46,6 +46,7 @@ if VERSION < v"1.7.0-beta1.0"
     end
 end
 
+include("combinators/mapsto.jl")
 include("combinators/half.jl")
 include("exp.jl")
 include("domains.jl")

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -34,7 +34,7 @@ Base.size(f::AffineTransform, n::Int) = @inbounds size(f)[n]
 (f::AffineTransform{(:ω,)})(x) = f.ω \ x
 (f::AffineTransform{(:μ,:σ)})(x) = f.σ * x + f.μ
 (f::AffineTransform{(:μ,:ω)})(x) = f.ω \ x + f.μ
-
+1
 rowsize(x) = ()
 rowsize(x::AbstractArray) = (size(x,1),)
 
@@ -166,7 +166,7 @@ function logdensity(d::Affine{(:μ,:ω)}, x)
 end 
 
 # logdensity(d::Affine{(:μ,:ω)}, x) = logdensity(d.parent, d.σ \ (x - d.μ))
-@inline function logdensity(d::Affine{(:μ,:σ), Tuple{AbstractVector, AbstractMatrix}}, x)
+@inline function logdensity(d::Affine{(:μ,:σ), P, Tuple{V,M}}, x) where {P, V<:AbstractVector, M<:AbstractMatrix}
     z = x - d.μ
     σ = d.σ
     if σ isa Factorization
@@ -174,14 +174,14 @@ end
     else
         ldiv!(factorize(σ), z)
     end
-    logdensity(d, z ↦ x)
+    logdensity(d.parent, z)
 end
     
 # logdensity(d::Affine{(:μ,:ω)}, x) = logdensity(d.parent, d.ω * (x - d.μ))
-@inline function logdensity(d::Affine{(:μ,:ω), Tuple{AbstractVector, AbstractMatrix}}, x)
+@inline function logdensity(d::Affine{(:μ,:ω), P,Tuple{V,M}}, x) where {P,V<:AbstractVector, M<:AbstractMatrix}
     z = x - d.μ
     lmul!(d.ω, z)
-    logdensity(d, z ↦ x)
+    logdensity(d.parent, z)
 end
 
 basemeasure(d::Affine) = affine(getfield(d, :f), basemeasure(d.parent))

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -10,11 +10,11 @@ params(f::AffineTransform) = getfield(f, :par)
 
 Base.propertynames(d::AffineTransform{N}) where {N} = N 
 
-@inline Base.inv(f::AffineTransform{(:μ,:σ)}) = affineTransform((μ = -(f.σ \ f.μ), ω = f.σ))
-@inline Base.inv(f::AffineTransform{(:μ,:ω)}) = affineTransform((μ = - f.ω * f.μ, σ = f.ω))
-@inline Base.inv(f::AffineTransform{(:σ,)}) = affineTransform((ω = f.σ,))
-@inline Base.inv(f::AffineTransform{(:ω,)}) = affineTransform((σ = f.ω,))
-@inline Base.inv(f::AffineTransform{(:μ,)}) = affineTransform((μ = -f.μ,))
+@inline Base.inv(f::AffineTransform{(:μ,:σ)}) = AffineTransform((μ = -(f.σ \ f.μ), ω = f.σ))
+@inline Base.inv(f::AffineTransform{(:μ,:ω)}) = AffineTransform((μ = - f.ω * f.μ, σ = f.ω))
+@inline Base.inv(f::AffineTransform{(:σ,)}) = AffineTransform((ω = f.σ,))
+@inline Base.inv(f::AffineTransform{(:ω,)}) = AffineTransform((σ = f.ω,))
+@inline Base.inv(f::AffineTransform{(:μ,)}) = AffineTransform((μ = -f.μ,))
 
 # `size(f) == (m,n)` means `f : ℝⁿ → ℝᵐ`  
 Base.size(f::AffineTransform{(:μ,:σ)}) = size(f.σ)

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -10,11 +10,11 @@ params(f::AffineTransform) = getfield(f, :par)
 
 Base.propertynames(d::AffineTransform{N}) where {N} = N 
 
-@inline Base.inv(f::AffineTransform{(:μ,:σ)}) = AffineTransform((μ = -(f.σ \ f.μ), ω = f.σ))
-@inline Base.inv(f::AffineTransform{(:μ,:ω)}) = AffineTransform((μ = - f.ω * f.μ, σ = f.ω))
-@inline Base.inv(f::AffineTransform{(:σ,)}) = AffineTransform((ω = f.σ,))
-@inline Base.inv(f::AffineTransform{(:ω,)}) = AffineTransform((σ = f.ω,))
-@inline Base.inv(f::AffineTransform{(:μ,)}) = AffineTransform((μ = -f.μ,))
+@inline Base.inv(f::AffineTransform{(:μ,:σ)}) = affineTransform((μ = -(f.σ \ f.μ), ω = f.σ))
+@inline Base.inv(f::AffineTransform{(:μ,:ω)}) = affineTransform((μ = - f.ω * f.μ, σ = f.ω))
+@inline Base.inv(f::AffineTransform{(:σ,)}) = affineTransform((ω = f.σ,))
+@inline Base.inv(f::AffineTransform{(:ω,)}) = affineTransform((σ = f.ω,))
+@inline Base.inv(f::AffineTransform{(:μ,)}) = affineTransform((μ = -f.μ,))
 
 # `size(f) == (m,n)` means `f : ℝⁿ → ℝᵐ`  
 Base.size(f::AffineTransform{(:μ,:σ)}) = size(f.σ)
@@ -34,6 +34,12 @@ Base.size(f::AffineTransform, n::Int) = @inbounds size(f)[n]
 (f::AffineTransform{(:ω,)})(x) = f.ω \ x
 (f::AffineTransform{(:μ,:σ)})(x) = f.σ * x + f.μ
 (f::AffineTransform{(:μ,:ω)})(x) = f.ω \ x + f.μ
+
+rowsize(x) = ()
+rowsize(x::AbstractArray) = (size(x,1),)
+
+colsize(x) = ()
+colsize(x::AbstractArray) = (size(x,2),)
 
 @inline function apply!(x, f::AffineTransform{(:μ,)}, z)
     x .= z .+ f.μ
@@ -184,7 +190,7 @@ basemeasure(d::Affine) = affine(getfield(d, :f), basemeasure(d.parent))
 # example it wouldn't make sense to apply a log-Jacobian to a point measure
 basemeasure(d::Affine{N,L}) where {N, L<:Lebesgue} = weightedmeasure(-logjac(d), d.parent)
 
-function basemeasure(d::Affine{N,L}) where {N, L<:PowerMeasure{typeof(identity), <:Lebesgue}}
+function basemeasure(d::Affine{N,L}) where {N, L<:PowerMeasure{typeof(identity), typeof(identity), <:Lebesgue}}
     weightedmeasure(-logjac(d), d.parent)
 end
 

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -134,8 +134,8 @@ logdensity(d::Affine, x::MapsTo) = logdensity(d.parent, x.x)
 
 function logdensity(d::Affine{(:σ,)}, x)
     z = d.σ \ x
-    @show z
-    println()
+    # @show z
+    # println()
     logdensity(d.parent, z)
 end
 

--- a/src/combinators/for.jl
+++ b/src/combinators/for.jl
@@ -75,12 +75,12 @@ julia> For(eachrow(rand(4,2))) do x Normal(x[1], x[2]) end |> marginals |> colle
 ```
 
 """
-For(f, dims...) = ProductMeasure(i -> f(i...), zip(dims...))
+For(f, dims...) = productmeasure(i -> f(i...), zip(dims...))
 
-For(f, inds::AbstractArray) = ProductMeasure(f, inds)
+For(f, inds::AbstractArray) = productmeasure(f, inds)
 
-For(f, n::Int) = ProductMeasure(f, 1:n)
-For(f, dims::Int...) = ProductMeasure(i -> f(Tuple(i)...), CartesianIndices(dims))
+For(f, n::Int) = productmeasure(f, 1:n)
+For(f, dims::Int...) = productmeasure(i -> f(Tuple(i)...), CartesianIndices(dims))
 
 
 function Base.eltype(d::ProductMeasure{F,I}) where {F,I<:AbstractArray}

--- a/src/combinators/mapsto.jl
+++ b/src/combinators/mapsto.jl
@@ -1,0 +1,19 @@
+struct MapsTo{X,Y}
+    x::X
+    y::Y
+end
+
+export ↦, mapsto
+
+mapsto(x,y) = x ↦ y
+
+↦(x::X,y::Y) where {X,Y} = MapsTo{X,Y}(x,y)
+
+Base.first(t::MapsTo) = t.x
+Base.last(t::MapsTo) = t.y
+
+Base.Pair(t::MapsTo) = t.x => t.y
+
+Base.show(io::IO, t::MapsTo) = print(t.x, " ↦ ", t.y)
+
+logdensity(d, t::MapsTo) = logdensity(d, t.y)

--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -29,7 +29,9 @@ using FillArrays: Fill
 
 export PowerMeasure
 
-const PowerMeasure{F,T,N,A} = ProductMeasure{F,Fill{T,N,A}}
+const PowerMeasure{F,S,T,N,A} = ProductMeasure{F,S,Fill{T,N,A}}
+
+Base.:^(μ::AbstractMeasure, ::Tuple{}) = μ
 
 function Base.:^(μ::AbstractMeasure, dims::Integer...)
     return μ ^ dims
@@ -40,13 +42,13 @@ function Base.:^(μ::M, dims::NTuple{N,I}) where {M<:AbstractMeasure,N,I<:Intege
 end
 
 # Same as PowerMeasure
-function Base.show(io::IO, d::ProductMeasure{F,<:Fill}) where {F}
+function Base.show(io::IO, d::ProductMeasure{F,S,<:Fill}) where {F,S}
     io = IOContext(io, :compact => true)
     print(io, d.f(first(d.pars)), " ^ ", size(d.pars))
 end
 
 # Same as PowerMeasure{F,T,1} where {F,T}
-function Base.show(io::IO, d::ProductMeasure{F,Fill{T,1,A}}) where {F,T,A}
+function Base.show(io::IO, d::ProductMeasure{F,S,Fill{T,1,A}}) where {F,S,T,A}
     io = IOContext(io, :compact => true)
     print(io, d.f(first(d.pars)), " ^ ", size(d.pars)[1])
 end
@@ -55,20 +57,24 @@ end
 
 
 
-params(d::ProductMeasure{F,<:Fill}) where {F} = params(first(marginals(d)))
+params(d::ProductMeasure{F,S,<:Fill}) where {F,S} = params(first(marginals(d)))
 
-params(::Type{P}) where {F,P<:ProductMeasure{F,<:Fill}} = params(D)
+params(::Type{P}) where {F,S,P<:ProductMeasure{F,S,<:Fill}} = params(D)
 
 # basemeasure(μ::PowerMeasure) = @inbounds basemeasure(first(μ.data))^size(μ.data)
 
 # Same as PowerMeasure
-@inline basemeasure(d::ProductMeasure{F,<:Fill}) where {F}= _basemeasure(d, (basemeasure(d.f(first(d.pars)))))
+@inline function basemeasure(d::ProductMeasure{F,S,<:Fill}) where {F,S}
+    _basemeasure(d, (basemeasure(d.f(first(d.pars)))))
+end
 
 # Same as PowerMeasure
-@inline _basemeasure(d::ProductMeasure{F,<:Fill}, b) where {F} = b ^ size(d.pars)
+@inline function _basemeasure(d::ProductMeasure{F,S,<:Fill}, b) where {F,S}
+    b ^ size(d.pars)
+end
 
 # Same as PowerMeasure
-@inline function _basemeasure(d::ProductMeasure{F,<:Fill}, b::FactoredBase) where {F}
+@inline function _basemeasure(d::ProductMeasure{F,S,<:Fill}, b::FactoredBase) where {F,S}
     n = length(d.pars)
     inbounds(x) = all(xj -> b.inbounds(xj), x)
     constℓ = n * b.constℓ
@@ -78,7 +84,7 @@ params(::Type{P}) where {F,P<:ProductMeasure{F,<:Fill}} = params(D)
 end
 
 # Same as PowerMeasure
-@inline function logdensity(d::ProductMeasure{F,<:Fill}, x) where {F}
+@inline function logdensity(d::ProductMeasure{F,S,<:Fill}, x) where {F,S}
     d1 = d.f(first(d.pars))
     sum(xj -> logdensity(d1, xj), x)
 end

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -73,21 +73,25 @@ end
 ###############################################################################
 # I <: Tuple
 
+struct TupleProductMeasure{T} <: AbstractProductMeasure
+    pars::T
+end
+
 export ⊗
-⊗(μs::AbstractMeasure...) = ProductMeasure(identity, μs)
+⊗(μs::AbstractMeasure...) = productmeasure(μs)
 
-marginals(d::ProductMeasure{F,T}) where {F, T<:Tuple} = map(d.f, d.pars)
+marginals(d::TupleProductMeasure{T}) where {F, T<:Tuple} = d.pars
 
-function Base.show(io::IO, μ::ProductMeasure{F,T}) where {F,T <: Tuple}
+function Base.show(io::IO, μ::TupleProductMeasure{T}) where {F,T <: Tuple}
     io = IOContext(io, :compact => true)
     print(io, join(string.(marginals(μ)), " ⊗ "))
 end
 
-@inline function logdensity(d::ProductMeasure{F,T}, x::Tuple) where {F,T<:Tuple}
-    mapreduce(logdensity, +, d.f.(d.pars), x)
+@inline function logdensity(d::TupleProductMeasure, x::Tuple) where {T<:Tuple}
+    mapreduce(logdensity, +, d.pars, x)
 end
 
-function Base.rand(rng::AbstractRNG, ::Type{T}, d::ProductMeasure{F,S,I}) where {T,F,S,I<:Tuple}
+function Base.rand(rng::AbstractRNG, ::Type{T}, d::TupleProductMeasure) where {T}
     rand.(d.pars)
 end
 

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -26,10 +26,7 @@ Base.size(μ::ProductMeasure) = size(marginals(μ))
 
 Base.length(m::ProductMeasure{T}) where {T} = length(marginals(μ))
 
-# TODO: Pull weights outside
-function basemeasure(d::ProductMeasure)
-    productmeasure(basekernel(d.f), d.pars)
-end
+basemeasure(d::ProductMeasure) = productmeasure(basekernel(d.f), d.pars)
 
 # TODO: Do we need these methods?
 # basemeasure(d::ProductMeasure) = ProductMeasure(basemeasure ∘ d.f, d.pars)

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -5,13 +5,17 @@ using Base: @propagate_inbounds
 import Base
 using FillArrays
 
-struct ProductMeasure{F,S,I} <: AbstractMeasure
+abstract type AbstractProductMeasure <: AbstractMeasure end
+
+
+struct ProductMeasure{F,S,I} <: AbstractProductMeasure
     f::Kernel{F,S}
     pars::I
 end
 
 
-
+# TODO: Test for equality without traversal, probably by first converting to a
+# canonical form
 function Base.:(==)(a::ProductMeasure, b::ProductMeasure)
     all(zip(a.pars, b.pars)) do (aᵢ, bᵢ)
         a.f(aᵢ) == b.f(bᵢ)

--- a/src/combinators/smart-constructors.jl
+++ b/src/combinators/smart-constructors.jl
@@ -98,3 +98,31 @@ end
 function weightedmeasure(ℓ, b::WeightedMeasure)
     weightedmeasure(ℓ + b.logweight, b.base)
 end 
+
+###############################################################################
+# Kernel
+
+kernel(μ, ops...) = Kernel(μ, ops)
+kernel(μ, op) = Kernel(μ, op)
+
+# kernel(Normal(μ=2))
+function kernel(μ::P) where {P <: AbstractMeasure}
+    (f, ops) = kernelfactor(μ)
+    Kernel(f,ops)
+end
+
+# kernel(Normal{(:μ,), Tuple{Int64}})
+function kernel(::Type{P}) where {P <: AbstractMeasure}
+    (f, ops) = kernelfactor(P)
+    Kernel(f,ops)
+end
+
+# kernel(::Type{P}, op::O) where {O, N, P<:ParameterizedMeasure{N}} = Kernel{constructorof(P),O}(op)
+
+function kernel(::Type{M}; ops...) where {M}
+    nt = NamedTuple(ops)
+    Kernel(M,nt)
+end
+
+kernel(f::Returns, op::typeof(identity)) = Kernel(f, op)
+kernel(f::Returns, op) = kernel(f, identity)

--- a/src/combinators/smart-constructors.jl
+++ b/src/combinators/smart-constructors.jl
@@ -68,6 +68,8 @@ end
 
 productmeasure(f, ops, pars) = ProductMeasure(kernel(f, ops), pars)
 
+productmeasure(μs::Tuple) = TupleProductMeasure(μs)
+
 productmeasure(f::Returns, ::typeof(identity), pars) = ProductMeasure(kernel(f, identity), pars)
 
 productmeasure(k::Kernel, pars) = productmeasure(k.f, k.ops, pars)
@@ -86,6 +88,8 @@ function productmeasure(f::Returns{W}, ::typeof(identity), pars) where {W <: Wei
     newbase = productmeasure(Returns(base), identity, pars)
     weightedmeasure(length(pars) * ℓ, newbase)
 end
+
+
 
 ###############################################################################
 # RestrictedMeasure

--- a/src/combinators/smart-constructors.jl
+++ b/src/combinators/smart-constructors.jl
@@ -125,20 +125,20 @@ kernel(μ, op) = Kernel(μ, op)
 # kernel(Normal(μ=2))
 function kernel(μ::P) where {P <: AbstractMeasure}
     (f, ops) = kernelfactor(μ)
-    Kernel(f,ops)
+    kernel(f,ops)
 end
 
 # kernel(Normal{(:μ,), Tuple{Int64}})
 function kernel(::Type{P}) where {P <: AbstractMeasure}
     (f, ops) = kernelfactor(P)
-    Kernel(f,ops)
+    kernel(f,ops)
 end
 
-# kernel(::Type{P}, op::O) where {O, N, P<:ParameterizedMeasure{N}} = Kernel{constructorof(P),O}(op)
+# kernel(::Type{P}, op::O) where {O, N, P<:ParameterizedMeasure{N}} = kernel{constructorof(P),O}(op)
 
 function kernel(::Type{M}; ops...) where {M}
     nt = NamedTuple(ops)
-    Kernel(M,nt)
+    kernel(M,nt)
 end
 
 kernel(f::Returns, op::typeof(identity)) = Kernel(f, op)

--- a/src/combinators/smart-constructors.jl
+++ b/src/combinators/smart-constructors.jl
@@ -66,9 +66,26 @@ end
 ###############################################################################
 # ProductMeasure
 
-productmeasure(f, pars) = ProductMeasure(f, pars)
+productmeasure(f, ops, pars) = ProductMeasure(kernel(f, ops), pars)
+
+productmeasure(f::Returns, ::typeof(identity), pars) = ProductMeasure(kernel(f, identity), pars)
+
+productmeasure(k::Kernel, pars) = productmeasure(k.f, k.ops, pars)
+
+productmeasure(f::Function, pars) = productmeasure(f, identity, pars)
 
 productmeasure(nt::NamedTuple) = productmeasure(identity, nt)
+
+
+productmeasure(f::Returns, ops, pars) = productmeasure(f, identity, pars)
+
+
+function productmeasure(f::Returns{W}, ::typeof(identity), pars) where {W <: WeightedMeasure}
+    ℓ = f.value.logweight
+    base = f.value.base
+    newbase = productmeasure(Returns(base), identity, pars)
+    weightedmeasure(length(pars) * ℓ, newbase)
+end
 
 ###############################################################################
 # RestrictedMeasure

--- a/src/density.jl
+++ b/src/density.jl
@@ -136,13 +136,13 @@ end
 end
 
 function logpdf(d::AbstractMeasure, x)
-    _logpdf(d, basemeasure(d), x, zero(Float64))
+    _logpdf(d, basemeasure(d), x, 0.0)
 end
 
-@inline function _logpdf(d::AbstractMeasure, β::AbstractMeasure, x, ℓ::Float64)
-    @show d
+@inline function _logpdf(d::AbstractMeasure, β::AbstractMeasure, x, ℓ)
+    # @show d
     # @show x
-    d === β && return ℓ
+    d == β && return ℓ
     Δℓ = logdensity(d, x)
     # @show Δℓ, d
     _logpdf(β, basemeasure(β), x, ℓ + Δℓ)

--- a/src/density.jl
+++ b/src/density.jl
@@ -136,10 +136,10 @@ end
 end
 
 function logpdf(d::AbstractMeasure, x)
-    _logpdf(d, basemeasure(d), x, 0.0)
+    _logpdf(d, basemeasure(d), x)
 end
 
-@inline function _logpdf(d::AbstractMeasure, β::AbstractMeasure, x, ℓ)
+@inline function _logpdf(d::AbstractMeasure, β::AbstractMeasure, x, ℓ=zero(Float64))
     # @show d
     # @show x
     d == β && return ℓ

--- a/src/density.jl
+++ b/src/density.jl
@@ -140,6 +140,8 @@ function logpdf(d::AbstractMeasure, x)
 end
 
 @inline function _logpdf(d::AbstractMeasure, β::AbstractMeasure, x, ℓ::Float64)
+    @show d
+    # @show x
     d === β && return ℓ
     Δℓ = logdensity(d, x)
     # @show Δℓ, d

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -53,6 +53,19 @@ end
 
 (k::Kernel)(x) = k.f(k.ops(x)) 
 
+"""
+For any `k::Kernel`, `basekernel` is expected to satisfy
+```
+basemeasure(k(p)) == basekernel(k)(p)
+```
+
+The main purpose of `basekernel` is to make it efficient to compute
+```
+basemeasure(d::ProductMeasure) = productmeasure(basekernel(d.f), d.pars)
+```
+"""
+function basekernel end
+
 
 # TODO: Using Core.Compiler.return_type, we can sometimes do better than this
 basekernel(f::Function) = basemeasure ∘ f

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -6,6 +6,9 @@ abstract type AbstractKernel <: AbstractMeasure end
 struct Kernel{F,S} <: AbstractKernel
     f::F
     ops::S
+
+    Kernel(::Type{T}, ops::S) where {T,S} = new{Type{T}, S}(T,ops)
+    Kernel(f::F, ops::S) where {F,S} = new{F, S}(f,ops)
 end
 
 """
@@ -28,31 +31,6 @@ function kernel end
 
 export kernel
 
-kernel(μ, ops...) = Kernel(μ, ops)
-kernel(μ, op) = Kernel(μ, op)
-
-# kernel(Normal(μ=2))
-function kernel(μ::P) where {P <: AbstractMeasure}
-    (f, ops) = kernelfactor(μ)
-    Kernel{instance_type(f), typeof(ops)}(f,ops)
-end
-
-
-
-# kernel(Normal{(:μ,), Tuple{Int64}})
-function kernel(::Type{P}) where {P <: AbstractMeasure}
-    (f, ops) = kernelfactor(P)
-    Kernel{instance_type(f), typeof(ops)}(f,ops)
-end
-
-
-
-# kernel(::Type{P}, op::O) where {O, N, P<:ParameterizedMeasure{N}} = Kernel{constructorof(P),O}(op)
-
-function kernel(::Type{M}; ops...) where {M}
-    nt = NamedTuple(ops)
-    Kernel{Type{M},typeof(nt)}(M,nt)
-end
 
 # kernel(Normal) do x
 #     (μ=x,σ=x^2)
@@ -73,11 +51,15 @@ function (k::Kernel{F,S})(x::Tuple) where {F, N, S<:NTuple{N,Symbol}}
     k.f(NamedTuple{k.ops}(x))
 end
 
-(k::Kernel)(x) = kernelapply(k.f, k.ops(x)) 
+(k::Kernel)(x) = k.f(k.ops(x)) 
 
-kernelapply(f, par::NamedTuple) = f(par)
 
-kernelapply(f, par::Tuple) = f(par...)
+# TODO: Using Core.Compiler.return_type, we can sometimes do better than this
+basekernel(f::Function) = basemeasure ∘ f
+
+basekernel(k::Kernel) = kernel(basekernel(k.f), k.ops)
+basekernel(f::Returns) = f
+
 
 # export kernelize
 
@@ -87,20 +69,3 @@ kernelapply(f, par::Tuple) = f(par...)
 # end
 
 export kernelfactor
-
-function kernelfactor(::Type{P}) where {N, P <: ParameterizedMeasure{N}}
-    (constructorof(P), N)
-end
-
-function kernelfactor(::P) where {N, P <: ParameterizedMeasure{N}}
-    (constructorof(P), N)
-end
-
-function kernelfactor(μ::ProductMeasure{F,<:Fill}) where {F}
-    k = kernel(first(marginals(μ)))
-    (p -> k.f(p)^size(μ), k.ops)
-end
-
-function kernelfactor(μ::ProductMeasure{F,A}) where {F,A<:AbstractArray}
-    (p -> set.(marginals(μ), params, p), μ.pars)
-end

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -67,7 +67,7 @@ basemeasure(d::ProductMeasure) = productmeasure(basekernel(d.f), d.pars)
 function basekernel end
 
 
-# TODO: Using Core.Compiler.return_type, we can sometimes do better than this
+# TODO: Find a way to do better than this
 basekernel(f::Function) = basemeasure ∘ f
 
 basekernel(k::Kernel) = kernel(basekernel(k.f), k.ops)

--- a/src/parameterized.jl
+++ b/src/parameterized.jl
@@ -69,3 +69,14 @@ params(::Type{PM}) where {N, PM<:ParameterizedMeasure{N}} = N
 function paramnames(μ, constraints::NamedTuple{N}) where {N}
     tuple((k for k in paramnames(μ) if k ∉ N)...)
 end
+
+###############################################################################
+# kernelfactor
+
+function kernelfactor(::Type{P}) where {N, P <: ParameterizedMeasure{N}}
+    (constructorof(P), N)
+end
+
+function kernelfactor(::P) where {N, P <: ParameterizedMeasure{N}}
+    (constructorof(P), N)
+end

--- a/src/thunks.jl
+++ b/src/thunks.jl
@@ -1,0 +1,25 @@
+abstract type LogdensityComputation end
+
+struct LogpdfComputation end
+
+struct BasemeasureComputation{B} <: LogdensityComputation
+    base::B
+end
+
+struct LogdensityThunk{C,M,X,L}
+    computation::C
+    measure::M
+    x::X
+    ℓ::L
+end
+
+function reduce_step(thunk :: LogdensityThunk, callback=Returns(nothing))
+    
+
+
+reduce_step(LogdensityThunk{M,B,X,L}, callback=Returns(nothing)) -> Union{LogdensityThunk, L}
+
+function logdensity(μ, b, x; cb=Returns(nothing))
+    f(thunk) = reduce_step(thunk, cb)
+    fix(f, LogdensityThunk(μ, b, x, zero(Float64)))
+end


### PR DESCRIPTION
# `basekernel`

For `k::Kernel`, `basekernel` has the property
```julia
basemeasure(k(p)) == basekernel(k)(p)
```
There are many cases for which
```julia
basekernel(k) isa Returns
```
in which case `p` doesn't matter. This can make things much more efficient, especially for large product measures.

# Smart Constructors

Many functions are now in terms of "smart constructors". These have lower-case names, for example `kernel` as opposed to `Kernel`. There's also a new `TupleProductMeasure` to handle cases like `Normal() ⊗ Lebesgue(ℝ)`.



A given smart constructor should have a very small number of methods that call the struct itself; the remainder should all make a small reduction step, usually calling another smart constructor.

# Changes to ProductMeasure

`ProductMeasure` is now in terms of `Kernel`.

# MapsTo

When computing the logpdf of an affine measure, we currently have to recompute the pullback many times. As a step toward improving this, this PR introduces a `MapsTo` combinator that works like 
```julia
julia> typeof([1,2] ↦ 3)
MeasureBase.MapsTo{Vector{Int64}, Int64}
```
The idea is that we can carry this around until the logpdf computation is done, and avoid recomputation in this way. 