### PR TITLE
faster basemeasure_sequence

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeasureBase"
 uuid = "fa1605e6-acd5-459c-a1e6-7e635759db14"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -73,19 +73,17 @@ end
 
 export basemeasure_sequence
 
-@inline function basemeasure_sequence(μ::M) where {M}  
-    depth = basemeasure_depth(μ)
-    basemeasure_sequence(μ, depth)
-end
-
-@generated function basemeasure_sequence(μ::M, ::StaticInt{N}) where {M,N}
-    quote
-        b_1 = μ
-        Base.Cartesian.@nexprs 10 i -> begin  # 10 is just some "big enough" number
-            b_{i+1} = basemeasure(b_{i})
+@inline function basemeasure_sequence(μ::M) where {M}
+    b_1 = μ
+    done = false
+    Base.Cartesian.@nexprs 10 i -> begin  # 10 is just some "big enough" number
+        b_{i+1} = if done nothing else basemeasure(b_{i}) end
+        if b_{i+1} isa typeof(b_{i})
+            done = true
+            b_{i+1} = nothing
         end
-        return Base.Cartesian.@ntuple $(N+1) b
     end
+    return filter(!isnothing, Base.Cartesian.@ntuple 10 b)
 end
 
 # @inline function basemeasure_depth(μ::M) where {M}


### PR DESCRIPTION
Before:
```julia
julia> @btime basemeasure_sequence(d) setup=(d = 5 * Normal(2,3))
  19.746 ns (1 allocation: 16 bytes)
(5.0 * Normal(μ = 2, σ = 3), Normal(μ = 2, σ = 3), static(0.39894228040143265) * Affine((σ = 3,), Lebesgue(ℝ)), Affine((σ = 3,), Lebesgue(ℝ)), 0.333333 * Lebesgue(ℝ), Lebesgue(ℝ), MeasureBase.LebesgueMeasure())
```

After:
```julia
julia> @btime basemeasure_sequence(d) setup=(d = 5 * Normal(2,3))
  1.152 ns (0 allocations: 0 bytes)
(5.0 * Normal(μ = 2, σ = 3), Normal(μ = 2, σ = 3), static(0.39894228040143265) * Affine((σ = 3,), Lebesgue(ℝ)), Affine((σ = 3,), Lebesgue(ℝ)), 0.333333 * Lebesgue(ℝ), Lebesgue(ℝ), MeasureBase.LebesgueMeasure())
```