### PR TITLE
AbstractMeasure

### DIFF
--- a/src/MeasureBase.jl
+++ b/src/MeasureBase.jl
@@ -38,6 +38,19 @@ export logdensity_def
 export basemeasure
 export basekernel
 export productmeasure
+
+"""
+    inssupport(m, x)
+    insupport(m)
+
+`insupport(m,x)` computes whether `x` is in the support of `m`.
+
+`insupport(m)` returns a function, and satisfies
+
+    insupport(m)(x) == insupport(m, x)
+"""
+function insupport end
+
 export insupport
 export getdof
 export transport_to
@@ -45,6 +58,8 @@ export transport_to
 include("insupport.jl")
 
 abstract type AbstractMeasure end
+
+AbstractMeasure(m::AbstractMeasure) = m
 
 using Static: @constprop
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -38,6 +38,8 @@ function test_interface(μ::M) where {M}
         @testset "$μ" begin
             μ = $μ
 
+            @test AbstractMeasure(μ) isa AbstractMeasure
+
             ###########################################################################
             # basemeasure_depth
             static_depth = @inferred basemeasure_depth(μ)


### PR DESCRIPTION
Add a method
```julia
AbstractMeasure(m::AbstractMeasure) = m
```

With this, we can always call `AbstractMeasure(...)` and get back a measure, without needing to first know whether the argument is already a measure. This is helps the code in Tilde to be simpler.

Unrelated but also thrown in is a docstring for `insupport`.