### PR TITLE
explicit type parameters for NamedTuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeasureBase"
 uuid = "fa1605e6-acd5-459c-a1e6-7e635759db14"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/parameterized.jl
+++ b/src/parameterized.jl
@@ -60,8 +60,6 @@ function (::Type{P})(args...) where {N,P<:ParameterizedMeasure{N}}
     return C(NamedTuple{N}(args))::C{N,typeof(args)}
 end
 
-# (::Type{P})(; kwargs...) where {P<:ParameterizedMeasure} = P(NamedTuple(kwargs))
-
 function ConstructionBase.setproperties(
     d::P,
     nt::NamedTuple,

--- a/src/parameterized.jl
+++ b/src/parameterized.jl
@@ -45,7 +45,7 @@ end
     kernel(f)
 end
 
-function (::Type{P})(nt::NamedTuple) where {N,P<:ParameterizedMeasure{N}}
+function (::Type{P})(nt::NamedTuple{K,T}) where {K,T,N,P<:ParameterizedMeasure{N}}
     C = constructorof(P)
     arg = NamedTuple{N}(nt)
     return _parameterized(C, arg)
@@ -60,7 +60,7 @@ function (::Type{P})(args...) where {N,P<:ParameterizedMeasure{N}}
     return C(NamedTuple{N}(args))::C{N,typeof(args)}
 end
 
-(::Type{P})(; kwargs...) where {P<:ParameterizedMeasure} = P(NamedTuple(kwargs))
+# (::Type{P})(; kwargs...) where {P<:ParameterizedMeasure} = P(NamedTuple(kwargs))
 
 function ConstructionBase.setproperties(
     d::P,


### PR DESCRIPTION
This PR makes two small changes. 

First, the `::NamedTuple` method for `ParameterizedMeasure`s is changed to `::NamedTuple{K,T}`, which hints to the compiler that methods should be specialized.

Second, the method
```julia
(::Type{P})(; kwargs...) where {P<:ParameterizedMeasure}
```
is redundant, since this is already handled by KeywordCalls. This PR removes this method.
